### PR TITLE
Replace phash by phash-image

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var fs = require('fs')
-var pHash = require('phash')
+var pHash = require('phash-image')
 var tmp = require('temporary')
 var gm = require('gm')
 var uuid = require('uuid')
@@ -15,7 +15,7 @@ module.exports = function(file,callback) {
       return callback(error)
     }
 
-    pHash.imageHash(jpeg,function(error, phash) {
+    pHash(jpeg,function(error, phash) {
       fs.unlinkSync(jpeg)
       tmpDir.rmdir()
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "gm": "^1.14.2",
-    "phash": "0.0.5",
+    "phash-image": "*",
     "temporary": "0.0.8",
     "uuid": "^1.4.1"
   }


### PR DESCRIPTION
The current phash doesn't support node .12, and it's been like that for 3 months, since phash it's a dependency of this project, it makes it unusable, phash-image works with node .12 and provides the same functionality as phash does, I just replaced the library and it seems to work fine.
